### PR TITLE
Add README and installation instructions

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,47 @@
+# Installation Guide
+
+This document explains how to install the dependencies required to build and run **Asteroids** on various platforms. You need a C++ compiler and the OpenGL development libraries (GL, GLU and GLUT). Clang or GCC are both suitable.
+
+## Windows
+
+1. Install [Visual Studio](https://visualstudio.microsoft.com) or [MinGW](http://mingw.org/).
+2. Download and install the [freeglut](http://freeglut.sourceforge.net/) development package. When using Visual Studio, copy the header and library files into your Visual Studio include and lib directories.
+3. Ensure that the freeglut `dll` is available in your PATH when running the program.
+4. Build the project by opening a Visual Studio command prompt and running `nmake` with the provided `Makefile`, or create a Visual Studio project and add the source files.
+
+## Windows Subsystem for Linux (WSL)
+
+WSL behaves much like a normal Linux environment. You can install the dependencies using `apt` and build with `make`:
+
+```bash
+sudo apt update
+sudo apt install build-essential freeglut3-dev
+cd /path/to/Asteroids/src
+make
+```
+
+## macOS
+
+1. Install Xcode from the App Store.
+2. Install the command line tools if you have not already done so (`xcode-select --install`).
+3. Install [Homebrew](https://brew.sh/) and then the GLUT package:
+
+```bash
+brew install freeglut
+```
+
+4. Build the project from the `src` directory using `make`.
+
+## Linux (Debian/Ubuntu)
+
+Install the compiler and OpenGL development packages from your package manager:
+
+```bash
+sudo apt update
+sudo apt install build-essential freeglut3-dev
+cd src
+make
+```
+
+After installation the `Asteroids` executable will be created in the `src` directory.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# Asteroids
+
+Asteroids is a simple C++ implementation of the classic arcade game. The project uses OpenGL and GLUT for rendering and input handling. It is intended as an educational sample showing how to structure a small game using C++ classes.
+
+**Table of Contents**
+
+1. [Project Structure](#project-structure)
+2. [Gameplay](#gameplay)
+3. [Building](#building)
+4. [Running](#running)
+5. [Controls](#controls)
+6. [Installation](#installation)
+
+## Project Structure
+
+The source code is located in the `src` directory. The most important files are:
+
+- `main.cpp` – entry point that sets up OpenGL/GLUT and starts the main loop.
+- `World.*` – manages the collection of in-game objects and the main update loop.
+- `Player.*`, `Asteroid.*`, `Bullet.*`, and `Actor.*` – classes representing the different actors in the game.
+- `TimeManager.*` – helper used for frame timing.
+- `Makefile` – provides a basic build process for Unix like systems.
+
+## Gameplay
+
+The game is a simple Asteroids clone. A player controlled ship moves and shoots asteroids. Objects collide and break into smaller pieces. The structure was designed for clarity rather than for production use.
+
+## Building
+
+A standard C++ compiler and the OpenGL libraries (GL, GLU, and GLUT) are required. Instructions for obtaining these prerequisites are provided in [INSTALLATION.md](INSTALLATION.md).
+
+To build on platforms where the dependencies are available through a package manager, run:
+
+```bash
+cd src
+make
+```
+
+This compiles the project into an executable called `Asteroids` in the `src` directory.
+
+## Running
+
+After building, run the executable from the `src` directory:
+
+```bash
+./Asteroids
+```
+
+A window will appear showing the game. Resize events and keyboard input are handled through GLUT.
+
+## Controls
+
+During gameplay, the following default controls are available:
+
+- `W`/`A`/`S`/`D` – Movement
+- `SPACE` – Shoot
+- `P` – Re-spawn the ship
+- `O` – Spawn asteroids
+- `L` – Delete all asteroids
+- `Q` – Quit the game
+
+## Installation
+
+Instructions for installing the dependencies on different operating systems can be found in [INSTALLATION.md](INSTALLATION.md).
+


### PR DESCRIPTION
## Summary
- document project structure and controls in a new README
- add `INSTALLATION.md` that explains how to set up dependencies for Windows, WSL, macOS, and Debian/Ubuntu

## Testing
- `make` *(fails: 'GL/freeglut.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c42c48b20832c8eb46e1201a0c459